### PR TITLE
Implement compiler fallback and clean object delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,14 @@ INTERNAL_TEST_DIR := $(TEST_DIR)/internal
 EXTERNAL_TEST_DIR := $(TEST_DIR)/external
 
 # 编译器设置
-COSMOCC := ~/cosmocc/bin/cosmocc
-AR := ~/cosmocc/bin/cosmoar
+COSMOCC ?= $(HOME)/cosmocc/bin/cosmocc
+AR ?= $(HOME)/cosmocc/bin/cosmoar
+ifeq ($(wildcard $(COSMOCC)),)
+COSMOCC := cc
+endif
+ifeq ($(wildcard $(AR)),)
+AR := ar
+endif
 
 # 编译选项
 CFLAGS := -Os -fomit-frame-pointer -fno-pie -fno-pic -fno-common -fno-plt -mcmodel=large -finline-functions
@@ -43,7 +49,7 @@ dirs:
 .PHONY: libxc
 libxc: dirs
 	@echo "构建libxc.a (使用$(CPUS)个核心)..."
-	@bash $(SCRIPTS_DIR)/build_libxc.sh $(CPUS)
+	@COSMOCC=$(COSMOCC) AR=$(AR) bash $(SCRIPTS_DIR)/build_libxc.sh $(CPUS)
 
 # 构建并运行测试
 .PHONY: test
@@ -53,14 +59,14 @@ test: test-internal test-external
 .PHONY: test-internal
 test-internal: libxc
 	@echo "构建并运行内部测试..."
-	@MAKE_JOBS=$(CPUS) bash $(SCRIPTS_DIR)/run_internal_tests.sh
+	@MAKE_JOBS=$(CPUS) COSMOCC=$(COSMOCC) bash $(SCRIPTS_DIR)/run_internal_tests.sh
 
 # 构建并运行外部测试
 .PHONY: test-external
 test-external: libxc
 	@echo "构建并运行外部测试..."
-	@MAKE_JOBS=$(CPUS) bash $(SCRIPTS_DIR)/run_external_tests.sh
-
+	@MAKE_JOBS=$(CPUS) COSMOCC=$(COSMOCC) bash $(SCRIPTS_DIR)/run_external_tests.sh
+	
 # 清理构建产物
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ XC是一个非常小的中层次C运行时库，具有类型系统和自动垃�
 ## 构建系统
 
 本项目使用Makefile和自定义构建脚本来管理构建过程。编译器使用cosmocc-4.0.2。
+If `cosmocc` is not installed, the build scripts fall back to the compiler specified in the `COSMOCC` environment variable (default: cc).
 
 ### 主要构建目标
 
@@ -78,4 +79,4 @@ cosmopolitan => infrax层 => xc运行时 => libxc.a + libxc.h
    ```bash
    cosmocc -I/path/to/xc/include your_file.c -L/path/to/xc/lib -lxc -o your_program
    ```
-ext c high level var sys lib
+If `cosmocc` is unavailable, set the `COSMOCC` environment variable to your C compiler (e.g., gcc) before running make.

--- a/scripts/build_libxc.sh
+++ b/scripts/build_libxc.sh
@@ -15,12 +15,12 @@ INCLUDE_DIR="${PROJECT_ROOT}/include"
 LIB_DIR="${PROJECT_ROOT}/lib"
 TMP_DIR="${PROJECT_ROOT}/tmp"
 
-# 设置编译器
-COSMOCC=~/cosmocc/bin/cosmocc
-AR=~/cosmocc/bin/cosmoar
+# 设置编译器，可通过环境变量覆盖
+COSMOCC="${COSMOCC:-$(command -v cosmocc 2>/dev/null || command -v cc)}"
+AR="${AR:-$(command -v cosmoar 2>/dev/null || command -v ar)}"
 
 # 设置编译选项
-CFLAGS="-Os -fomit-frame-pointer -fno-pie -fno-pic -fno-common -fno-plt -mcmodel=large -finline-functions -I${SRC_DIR} -I${SRC_DIR}/infrax -I${INCLUDE_DIR} -I~/cosmocc/include"
+CFLAGS="-Os -fomit-frame-pointer -fno-pie -fno-pic -fno-common -fno-plt -mcmodel=large -finline-functions -I${SRC_DIR} -I${SRC_DIR}/infrax -I${INCLUDE_DIR}"
 
 # 创建输出目录（如果不存在）
 mkdir -p "${LIB_DIR}"

--- a/scripts/build_test_xc.sh
+++ b/scripts/build_test_xc.sh
@@ -15,11 +15,11 @@ BIN_DIR="${PROJECT_ROOT}/bin"
 TEST_DIR="${PROJECT_ROOT}/test"
 LIB_DIR="${PROJECT_ROOT}/lib"
 
-# 设置编译器
-COSMOCC="${PROJECT_ROOT}/../Downloads/cosmocc-4.0.2/bin/cosmocc"
+# 设置编译器，可通过环境变量覆盖
+COSMOCC="${COSMOCC:-$(command -v cosmocc 2>/dev/null || command -v cc)}"
 
 # 设置编译选项
-CFLAGS="-Os -fomit-frame-pointer -fno-pie -fno-pic -fno-common -fno-plt -mcmodel=large -finline-functions -I${PROJECT_ROOT}/src -I${PROJECT_ROOT}/src/infrax -I${PROJECT_ROOT}/include -I${SRC_DIR} -I${PROJECT_ROOT}/../Downloads/cosmocc-4.0.2/include"
+CFLAGS="-Os -fomit-frame-pointer -fno-pie -fno-pic -fno-common -fno-plt -mcmodel=large -finline-functions -I${PROJECT_ROOT}/src -I${PROJECT_ROOT}/src/infrax -I${PROJECT_ROOT}/include -I${SRC_DIR}"
 LDFLAGS="-static -Wl,--gc-sections -Wl,--build-id=none -L${LIB_DIR} -lxc"
 
 # 创建bin目录（如果不存在）

--- a/scripts/run_external_tests.sh
+++ b/scripts/run_external_tests.sh
@@ -16,11 +16,11 @@ BIN_DIR="${PROJECT_ROOT}/bin"
 TEST_DIR="${PROJECT_ROOT}/test"
 EXTERNAL_TEST_DIR="${TEST_DIR}/external"
 
-# 设置编译器
-COSMOCC=~/cosmocc/bin/cosmocc
+# 设置编译器，可通过环境变量覆盖
+COSMOCC="${COSMOCC:-$(command -v cosmocc 2>/dev/null || command -v cc)}"
 
 # 设置编译选项 - 注意这里只包含公共头文件目录
-CFLAGS="-Os -g -I${INCLUDE_DIR} -I${EXTERNAL_TEST_DIR} -I~/cosmocc/include"
+CFLAGS="-Os -g -I${INCLUDE_DIR} -I${EXTERNAL_TEST_DIR}"
 
 # 创建输出目录（如果不存在）
 mkdir -p "${BIN_DIR}"
@@ -71,4 +71,4 @@ ls -la "${BIN_DIR}/test_external.exe"
 echo -e "\nrun_external_tests.sh: 运行外部测试程序: ${BIN_DIR}/test_external.exe\n"
 "${BIN_DIR}/test_external.exe"
 
-echo -e "\nrun_external_tests.sh: 外部测试结束!" 
+echo -e "\nrun_external_tests.sh: 外部测试结束!"

--- a/scripts/run_internal_tests.sh
+++ b/scripts/run_internal_tests.sh
@@ -17,11 +17,11 @@ BIN_DIR="${PROJECT_ROOT}/bin"
 TEST_DIR="${PROJECT_ROOT}/test"
 INTERNAL_TEST_DIR="${TEST_DIR}/internal"
 
-# 设置编译器
-COSMOCC=~/cosmocc/bin/cosmocc
+# 设置编译器，可通过环境变量覆盖
+COSMOCC="${COSMOCC:-$(command -v cosmocc 2>/dev/null || command -v cc)}"
 
 # 设置编译选项
-CFLAGS="-Os -g -I${SRC_DIR} -I${SRC_DIR}/infrax -I${INCLUDE_DIR} -I${INTERNAL_TEST_DIR} -I~/cosmocc/include"
+CFLAGS="-Os -g -I${SRC_DIR} -I${SRC_DIR}/infrax -I${INCLUDE_DIR} -I${INTERNAL_TEST_DIR}"
 
 # 创建输出目录（如果不存在）
 mkdir -p "${BIN_DIR}"
@@ -69,4 +69,4 @@ ls -la "${BIN_DIR}/test_internal.exe"
 echo -e "\nrun_internal_tests.sh: 运行内部测试程序: ${BIN_DIR}/test_internal.exe\n"
 "${BIN_DIR}/test_internal.exe"
 
-echo -e "\nrun_internal_tests.sh: 内部测试结束!" 
+echo -e "\nrun_internal_tests.sh: 内部测试结束!"

--- a/src/xc/xc_internal.h
+++ b/src/xc/xc_internal.h
@@ -295,7 +295,7 @@ int xc_array_index_of_from(xc_runtime_t *rt, xc_object_t *arr, xc_object_t *valu
 xc_object_t *xc_object_get(xc_runtime_t *rt, xc_object_t *obj, const char *key);
 void xc_object_set(xc_runtime_t *rt, xc_object_t *obj, const char *key, xc_object_t *value);
 bool xc_object_has(xc_runtime_t *rt, xc_object_t *obj, const char *key);
-void xc_object_delete(xc_runtime_t *rt, xc_object_t *obj, const char *key);
+bool xc_object_delete(xc_runtime_t *rt, xc_object_t *obj, const char *key);
 xc_object_t *xc_function_call(xc_runtime_t *rt, xc_object_t *func, xc_object_t *this_obj, size_t argc, xc_object_t **argv);
 
 /*

--- a/src/xc/xc_types/xc_object.c
+++ b/src/xc/xc_types/xc_object.c
@@ -248,44 +248,26 @@ bool xc_object_has(xc_runtime_t *rt, xc_object_t *obj, const char *key) {
     return find_property((xc_object_data_t *)obj, key) != NULL;
 }
 
-//TODO change void to bool
-void xc_object_delete(xc_runtime_t *rt, xc_object_t *obj, const char *key) {
+// Delete a property from an object. Returns true if the key existed.
+bool xc_object_delete(xc_runtime_t *rt, xc_object_t *obj, const char *key) {
     assert(xc_is_object(rt, obj));
     xc_object_data_t *object = (xc_object_data_t *)obj;
-    
+
     for (size_t i = 0; i < object->count; i++) {
         const char *prop_key = xc_string_value(rt, object->properties[i].key);
         if (strcmp(prop_key, key) == 0) {
-            // /* Release property references */
-            // if (object->properties[i].key) {
-            //     xc_gc_release(rt, object->properties[i].key);
-            // }
-            // if (object->properties[i].value) {
-            //     xc_gc_release(rt, object->properties[i].value);
-            // }
-            // 在纯 GC 系统中，我们不需要显式释放引用
-            // 只需要移除引用关系，让 GC 处理不可达对象
-// 重要的不是 memmove 本身，而是引用关系的断开：
-// 在 memmove 之前，对象持有对 "age" 值的引用
-// memmove 后，对象不再持有这个引用
-// 如果没有其他地方引用这个值，它就变成了"不可达"对象
-// 下次 GC 运行时，会识别并回收这个不可达对象
-            /* Move remaining properties */
             memmove(&object->properties[i], &object->properties[i + 1],
                    (object->count - i - 1) * sizeof(xc_property_t));
             object->count--;
 
-            /* Clear the last slot */
             if (object->count < object->capacity) {
                 object->properties[object->count].key = NULL;
                 object->properties[object->count].value = NULL;
             }
-            // // 可选：标记对象为灰色，触发重新标记
-            // xc_gc_mark(rt, obj);
-            return;//return true;
+            return true;
         }
     }
-    // return false;
+    return false;
 }
 
 /* Type checking */


### PR DESCRIPTION
## Summary
- allow build scripts to fall back to `cc` when `cosmocc` isn't installed
- clean up `xc_object_delete` implementation
- update README with compiler override instructions

## Testing
- `make test-internal`
- `make test-external`
